### PR TITLE
Add `sd_product` tag to auto-gen pr. layout

### DIFF
--- a/layouts/auto_generated_product.tpl
+++ b/layouts/auto_generated_product.tpl
@@ -13,6 +13,8 @@
   {% include "edicy-tools-variables" %}
   {% include "html-head" product_page: true %}
   {% include "edicy-tools-styles" %}
+
+  {% sd_product %}
 </head>
 
 <body class="item-page product-page content-page{% if editmode or site.has_many_languages? %} multilingual{% endif %}">


### PR DESCRIPTION
Include `sd_product` tag in Auto-rendered Product layout to render out product structured data.

Closes #157 